### PR TITLE
[feature] add the ability to parse sub expression trees in wait().then

### DIFF
--- a/transforms/convert-module-for-to-setup-test/__testfixtures__/nested-module-with-async.input.js
+++ b/transforms/convert-module-for-to-setup-test/__testfixtures__/nested-module-with-async.input.js
@@ -1,0 +1,10 @@
+import { module, test } from 'qunit';
+import wait from 'ember-test-helpers/wait';
+
+module('Integration | Component | FooBar');
+
+test('absolute value works', function(assert) {
+  return wait().then(() => {
+    click('.foo');
+  })
+});

--- a/transforms/convert-module-for-to-setup-test/__testfixtures__/nested-module-with-async.output.js
+++ b/transforms/convert-module-for-to-setup-test/__testfixtures__/nested-module-with-async.output.js
@@ -1,0 +1,9 @@
+import { module, test } from 'qunit';
+import { settled } from '@ember/test-helpers';
+
+module('Integration | Component | FooBar', function() {
+  test('absolute value works', async function(assert) {
+    await settled();
+    await click('.foo');
+  });
+});


### PR DESCRIPTION
fails to work because updateWait usage:

```
root.find(j.CallExpression, { callee: { name: importedName } }).forEach(p => {
    p.node.callee.name = 'settled';
});
```

Should this above code also convert the .then call to await? 