### PR TITLE
fix: handle async lifecycle hooks like beforeEach

### DIFF
--- a/transforms/convert-module-for-to-setup-test/__testfixtures__/before-each-async.input.js
+++ b/transforms/convert-module-for-to-setup-test/__testfixtures__/before-each-async.input.js
@@ -1,0 +1,14 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | FooBar', {
+  integration: true,
+  async beforeEach() {
+    await doStuff();
+  },
+});
+
+test('it happens', function() {
+  this.render(hbs`derp`);
+});

--- a/transforms/convert-module-for-to-setup-test/__testfixtures__/before-each-async.output.js
+++ b/transforms/convert-module-for-to-setup-test/__testfixtures__/before-each-async.output.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | FooBar', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    await doStuff();
+  });
+
+  test('it happens', async function() {
+    await render(hbs`derp`);
+  });
+});

--- a/transforms/convert-module-for-to-setup-test/index.js
+++ b/transforms/convert-module-for-to-setup-test/index.js
@@ -394,6 +394,10 @@ module.exports = function(file, api) {
               ? j.functionExpression(null, property.params, property.body)
               : property.value;
 
+          if (property.async) {
+            value.async = true;
+          }
+
           if (moduleInfo.setupType) {
             let expressionCollection = j(value);
 


### PR DESCRIPTION
Without this fix, the beforeEach lifecycle hook will be missing the `async` keyword which is a syntax error.